### PR TITLE
Optimize component io access.

### DIFF
--- a/src/main/java/de/ecconia/java/opentung/components/CompBlotter.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompBlotter.java
@@ -1,6 +1,7 @@
 package de.ecconia.java.opentung.components;
 
 import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -36,7 +37,12 @@ public class CompBlotter extends Component implements Powerable, Updateable
 	public CompBlotter(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
+		outputBlot = blots.get(0);
 	}
+
+	private Peg inputPeg;
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -58,19 +64,18 @@ public class CompBlotter extends Component implements Powerable, Updateable
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean input = pegs.get(0).getCluster().isActive();
+		boolean input = inputPeg.getCluster().isActive();
 		if(powered != input)
 		{
 			powered = input;
-			simulation.mightHaveChanged(blots.get(0).getCluster());
+			simulation.mightHaveChanged(outputBlot.getCluster());
 		}
 	}
 }

--- a/src/main/java/de/ecconia/java/opentung/components/CompButton.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompButton.java
@@ -1,5 +1,6 @@
 package de.ecconia.java.opentung.components;
 
+import de.ecconia.java.opentung.components.conductor.Blot;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -37,7 +38,10 @@ public class CompButton extends Component implements Powerable, Updateable, Hold
 	public CompButton(CompContainer parent)
 	{
 		super(parent);
+		outputBlot = blots.get(0);
 	}
+
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -62,7 +66,7 @@ public class CompButton extends Component implements Powerable, Updateable, Hold
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		blots.get(0).getCluster().update(simulation);
+		outputBlot.getCluster().update(simulation);
 	}
 	
 	@Override

--- a/src/main/java/de/ecconia/java/opentung/components/CompDelayer.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompDelayer.java
@@ -38,7 +38,12 @@ public class CompDelayer extends Component implements Powerable, Updateable
 	public CompDelayer(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
+		outputBlot = blots.get(0);
 	}
+
+	private Peg inputPeg;
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -67,15 +72,14 @@ public class CompDelayer extends Component implements Powerable, Updateable
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean input = pegs.get(0).getCluster().isActive();
+		boolean input = inputPeg.getCluster().isActive();
 		if(delayCount == 9)
 		{
 			changeOutputState(simulation, true);
@@ -101,7 +105,7 @@ public class CompDelayer extends Component implements Powerable, Updateable
 		if(powered != state)
 		{
 			powered = state;
-			simulation.mightHaveChanged(blots.get(0).getCluster());
+			simulation.mightHaveChanged(outputBlot.getCluster());
 		}
 	}
 }

--- a/src/main/java/de/ecconia/java/opentung/components/CompDisplay.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompDisplay.java
@@ -1,5 +1,6 @@
 package de.ecconia.java.opentung.components;
 
+import de.ecconia.java.opentung.components.conductor.Blot;
 import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
@@ -37,7 +38,10 @@ public class CompDisplay extends Component implements Updateable, Colorable
 	public CompDisplay(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
 	}
+
+	private Peg inputPeg;
 	
 	public void setColorRaw(Color color)
 	{
@@ -52,7 +56,7 @@ public class CompDisplay extends Component implements Updateable, Colorable
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean on = pegs.get(0).getCluster().isActive();
+		boolean on = inputPeg.getCluster().isActive();
 		simulation.setColor(colorID, on ? colorRaw : Color.displayOff);
 	}
 	

--- a/src/main/java/de/ecconia/java/opentung/components/CompInverter.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompInverter.java
@@ -1,6 +1,7 @@
 package de.ecconia.java.opentung.components;
 
 import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -36,7 +37,12 @@ public class CompInverter extends Component implements Powerable, Updateable
 	public CompInverter(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
+		outputBlot = blots.get(0);
 	}
+
+	private Peg inputPeg;
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -58,20 +64,19 @@ public class CompInverter extends Component implements Powerable, Updateable
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean input = pegs.get(0).getCluster().isActive();
+		boolean input = inputPeg.getCluster().isActive();
 		//If they are the same, invalid, has to be inverted.
 		if(powered == input)
 		{
 			powered = !input;
-			simulation.mightHaveChanged(blots.get(0).getCluster());
+			simulation.mightHaveChanged(outputBlot.getCluster());
 		}
 	}
 }

--- a/src/main/java/de/ecconia/java/opentung/components/CompNoisemaker.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompNoisemaker.java
@@ -1,5 +1,6 @@
 package de.ecconia.java.opentung.components;
 
+import de.ecconia.java.opentung.components.conductor.Blot;
 import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
@@ -35,7 +36,10 @@ public class CompNoisemaker extends Component implements Updateable, Colorable
 	public CompNoisemaker(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
 	}
+
+	private Peg inputPeg;
 	
 	public void setFrequency(float frequency)
 	{
@@ -44,7 +48,7 @@ public class CompNoisemaker extends Component implements Updateable, Colorable
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean on = pegs.get(0).getCluster().isActive();
+		boolean on = inputPeg.getCluster().isActive();
 		simulation.setColor(colorID, on ? Color.noisemakerON : Color.noisemakerOFF);
 	}
 	

--- a/src/main/java/de/ecconia/java/opentung/components/CompPanelButton.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompPanelButton.java
@@ -1,6 +1,7 @@
 package de.ecconia.java.opentung.components;
 
 import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -38,7 +39,10 @@ public class CompPanelButton extends Component implements Powerable, Updateable,
 	public CompPanelButton(CompContainer parent)
 	{
 		super(parent);
+		outputBlot = blots.get(0);
 	}
+
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -60,15 +64,14 @@ public class CompPanelButton extends Component implements Powerable, Updateable,
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		blots.get(0).getCluster().update(simulation);
+		outputBlot.getCluster().update(simulation);
 	}
 	
 	@Override

--- a/src/main/java/de/ecconia/java/opentung/components/CompPanelDisplay.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompPanelDisplay.java
@@ -1,5 +1,7 @@
 package de.ecconia.java.opentung.components;
 
+import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -37,7 +39,10 @@ public class CompPanelDisplay extends Component implements Updateable, Colorable
 	public CompPanelDisplay(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
 	}
+
+	private Peg inputPeg;
 	
 	public void setColorRaw(Color color)
 	{
@@ -52,7 +57,7 @@ public class CompPanelDisplay extends Component implements Updateable, Colorable
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean on = pegs.get(0).getCluster().isActive();
+		boolean on = inputPeg.getCluster().isActive();
 		simulation.setColor(colorID, on ? colorRaw : Color.displayOff);
 	}
 	

--- a/src/main/java/de/ecconia/java/opentung/components/CompPanelSwitch.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompPanelSwitch.java
@@ -1,6 +1,7 @@
 package de.ecconia.java.opentung.components;
 
 import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -37,7 +38,10 @@ public class CompPanelSwitch extends Component implements Powerable, Updateable
 	public CompPanelSwitch(CompContainer parent)
 	{
 		super(parent);
+		outputBlot = blots.get(0);
 	}
+
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -59,15 +63,14 @@ public class CompPanelSwitch extends Component implements Powerable, Updateable
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		blots.get(0).getCluster().update(simulation);
+		outputBlot.getCluster().update(simulation);
 	}
 	
 	@Override

--- a/src/main/java/de/ecconia/java/opentung/components/CompSwitch.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompSwitch.java
@@ -1,6 +1,7 @@
 package de.ecconia.java.opentung.components;
 
 import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -36,7 +37,10 @@ public class CompSwitch extends Component implements Powerable, Updateable
 	public CompSwitch(CompContainer parent)
 	{
 		super(parent);
+		outputBlot = blots.get(0);
 	}
+
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -58,15 +62,14 @@ public class CompSwitch extends Component implements Powerable, Updateable
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		blots.get(0).getCluster().update(simulation); //Just forward the problem to the cluster.
+		outputBlot.getCluster().update(simulation); //Just forward the problem to the cluster.
 	}
 	
 	@Override

--- a/src/main/java/de/ecconia/java/opentung/components/CompThroughBlotter.java
+++ b/src/main/java/de/ecconia/java/opentung/components/CompThroughBlotter.java
@@ -1,6 +1,7 @@
 package de.ecconia.java.opentung.components;
 
 import de.ecconia.java.opentung.components.conductor.Blot;
+import de.ecconia.java.opentung.components.conductor.Peg;
 import de.ecconia.java.opentung.components.fragments.Color;
 import de.ecconia.java.opentung.components.fragments.CubeFull;
 import de.ecconia.java.opentung.components.fragments.CubeOpen;
@@ -36,7 +37,12 @@ public class CompThroughBlotter extends Component implements Powerable, Updateab
 	public CompThroughBlotter(CompContainer parent)
 	{
 		super(parent);
+		inputPeg = pegs.get(0);
+		outputBlot = blots.get(0);
 	}
+
+	private Peg inputPeg;
+	private Blot outputBlot;
 	
 	private boolean powered;
 	
@@ -58,19 +64,18 @@ public class CompThroughBlotter extends Component implements Powerable, Updateab
 		//Default state is off. Only update on ON.
 		if(powered)
 		{
-			Blot blot = blots.get(0);
-			blot.forceUpdateON();
+			outputBlot.forceUpdateON();
 		}
 	}
 	
 	@Override
 	public void update(SimulationManager simulation)
 	{
-		boolean input = pegs.get(0).getCluster().isActive();
+		boolean input = inputPeg.getCluster().isActive();
 		if(powered != input)
 		{
 			powered = input;
-			simulation.mightHaveChanged(blots.get(0).getCluster());
+			simulation.mightHaveChanged(outputBlot.getCluster());
 		}
 	}
 }


### PR DESCRIPTION
Store the inputs/outputs of components inside private fields instead of always accessing the lists when updating.